### PR TITLE
browser: cleanup followup to #1

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -5,30 +5,29 @@ var inherits = require('inherits')
 var zeroBuffer = new Buffer(128)
 zeroBuffer.fill(0)
 
-module.exports = function createHmac(alg, key) {
-  return new Hmac(alg, key)
-}
-inherits(Hmac, Transform)
-function Hmac (alg, key) {
+function Hmac(alg, key) {
+  Transform.call(this)
 
-  Transform.call(this);
-  this._opad = opad
-  this._alg = alg
+  if (typeof key === 'string') {
+    key = new Buffer(key)
+  }
 
   var blocksize = (alg === 'sha512' || alg === 'sha384') ? 128 : 64
 
-  key = this._key = (typeof key === 'string') ? new Buffer(key) : key
+  this._alg = alg
+  this._key = key
 
-  if(key.length > blocksize) {
+  if (key.length > blocksize) {
     key = createHash(alg).update(key).digest()
-  } else if(key.length < blocksize) {
+
+  } else if (key.length < blocksize) {
     key = Buffer.concat([key, zeroBuffer], blocksize)
   }
 
   var ipad = this._ipad = new Buffer(blocksize)
   var opad = this._opad = new Buffer(blocksize)
 
-  for(var i = 0; i < blocksize; i++) {
+  for (var i = 0; i < blocksize; i++) {
     ipad[i] = key[i] ^ 0x36
     opad[i] = key[i] ^ 0x5C
   }
@@ -36,32 +35,36 @@ function Hmac (alg, key) {
   this._hash = createHash(alg).update(ipad)
 }
 
+inherits(Hmac, Transform)
+
 Hmac.prototype.update = function (data, enc) {
   if (typeof data === 'string') {
     data = new Buffer(data, enc)
   }
+
   this._hash.update(data)
   return this
 }
 
 Hmac.prototype._transform = function (data, enc, next) {
-  if (enc) {
-    data = new Buffer(data, enc)
-  }
   this._hash.update(data)
+
   next()
 }
 
 Hmac.prototype._flush = function (next) {
   this.push(this.digest())
+
   next()
 }
 
 Hmac.prototype.digest = function (enc) {
   var h = this._hash.digest()
-  var outData = createHash(this._alg).update(this._opad).update(h).digest();
-  if (enc) {
-    outData = outData.toString(enc)
-  }
-  return outData
+  var outData = createHash(this._alg).update(this._opad).update(h).digest()
+
+  return enc ? outData.toString() : outData
+}
+
+module.exports = function createHmac(alg, key) {
+  return new Hmac(alg, key)
 }

--- a/browser.js
+++ b/browser.js
@@ -1,9 +1,11 @@
 'use strict';
 var createHash = require('create-hash/browser');
-var Transform = require('stream').Transform;
 var inherits = require('inherits')
-var zeroBuffer = new Buffer(128)
-zeroBuffer.fill(0)
+
+var Transform = require('stream').Transform
+
+var ZEROS = new Buffer(128)
+ZEROS.fill(0)
 
 function Hmac(alg, key) {
   Transform.call(this)
@@ -21,7 +23,7 @@ function Hmac(alg, key) {
     key = createHash(alg).update(key).digest()
 
   } else if (key.length < blocksize) {
-    key = Buffer.concat([key, zeroBuffer], blocksize)
+    key = Buffer.concat([key, ZEROS], blocksize)
   }
 
   var ipad = this._ipad = new Buffer(blocksize)


### PR DESCRIPTION
This is a follow up to #1.

It removes several instances of a variables being used before they have been declared. 

Removes the unnecessary encoding functionality from [`_transform` as `decodeStrings` has not been changed](http://nodejs.org/api/stream.html#stream_transform_transform_chunk_encoding_callback).

General jshint syntax cleanup.