### PR TITLE
use hash implimentations directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,12 @@
     "tape": "^3.0.3"
   },
   "dependencies": {
+    "cipher-base": "^1.0.3",
     "create-hash": "^1.1.0",
-    "inherits": "^2.0.1"
+    "inherits": "^2.0.1",
+    "ripemd160": "^1.0.0",
+    "safe-buffer": "^5.0.1",
+    "sha.js": "^2.4.8"
   },
   "browser": "./browser.js"
 }


### PR DESCRIPTION
this goes directly to the underlying implementations instead of instead of going through create-hash, create-hash is still a dependency because we grab the md5 implementation from it.

Should offer a modest speedup for pbkdf2 as it avoids allocating 2 extra stream objects per hash