### PR TITLE
 Allow for fast cached HMACs

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,12 +1,8 @@
 'use strict'
 var inherits = require('inherits')
-var Legacy = require('./legacy')
 var Base = require('cipher-base')
 var Buffer = require('safe-buffer').Buffer
-var md5 = require('create-hash/md5')
-var RIPEMD160 = require('ripemd160')
-
-var sha = require('sha.js')
+var createHash = require('create-hash')
 
 var ZEROS = Buffer.alloc(128)
 
@@ -21,7 +17,7 @@ function Hmac (alg, key) {
   this._alg = alg
   this._key = key
   if (key.length > blocksize) {
-    var hash = alg === 'rmd160' ? new RIPEMD160() : sha(alg)
+    var hash = createHash(alg)
     key = hash.update(key).digest()
   }
   if (key.length < blocksize) {
@@ -35,7 +31,7 @@ function Hmac (alg, key) {
     ipad[i] = key[i] ^ 0x36
     opad[i] = key[i] ^ 0x5C
   }
-  this._hash = alg === 'rmd160' ? new RIPEMD160() : sha(alg)
+  this._hash = createHash(alg)
   this._hash.update(ipad)
 }
 
@@ -47,17 +43,10 @@ Hmac.prototype._update = function (data) {
 
 Hmac.prototype._final = function () {
   var h = this._hash.digest()
-  var hash = this._alg === 'rmd160' ? new RIPEMD160() : sha(this._alg)
+  var hash = createHash(this._alg)
   return hash.update(this._opad).update(h).digest()
 }
 
 module.exports = function createHmac (alg, key) {
-  alg = alg.toLowerCase()
-  if (alg === 'rmd160' || alg === 'ripemd160') {
-    return new Hmac('rmd160', key)
-  }
-  if (alg === 'md5') {
-    return new Legacy(md5, key)
-  }
   return new Hmac(alg, key)
 }

--- a/browser.js
+++ b/browser.js
@@ -23,7 +23,8 @@ function Hmac (alg, key) {
   if (key.length > blocksize) {
     var hash = alg === 'rmd160' ? new RIPEMD160() : sha(alg)
     key = hash.update(key).digest()
-  } else if (key.length < blocksize) {
+  }
+  if (key.length < blocksize) {
     key = Buffer.concat([key, ZEROS], blocksize)
   }
 

--- a/browser.js
+++ b/browser.js
@@ -39,7 +39,7 @@ function Hmac (alg, key) {
 inherits(Hmac, Base)
 
 Hmac.prototype._update = function (data) {
-  this._hash.update(data)
+  this._ihash.update(data)
 }
 
 Hmac.prototype._final = function () {

--- a/browser.js
+++ b/browser.js
@@ -14,8 +14,6 @@ function Hmac (alg, key) {
 
   var blocksize = (alg === 'sha512' || alg === 'sha384') ? 128 : 64
 
-  this._alg = alg
-  this._key = key
   if (key.length > blocksize) {
     var hash = createHash(alg)
     key = hash.update(key).digest()
@@ -24,15 +22,18 @@ function Hmac (alg, key) {
     key = Buffer.concat([key, ZEROS], blocksize)
   }
 
-  var ipad = this._ipad = Buffer.allocUnsafe(blocksize)
-  var opad = this._opad = Buffer.allocUnsafe(blocksize)
+  var ipad = Buffer.allocUnsafe(blocksize)
+  var opad = Buffer.allocUnsafe(blocksize)
 
   for (var i = 0; i < blocksize; i++) {
     ipad[i] = key[i] ^ 0x36
     opad[i] = key[i] ^ 0x5C
   }
-  this._hash = createHash(alg)
-  this._hash.update(ipad)
+
+  this._ihash = createHash(alg)
+  this._ohash = createHash(alg)
+  this._ihash.update(ipad)
+  this._ohash.update(opad)
 }
 
 inherits(Hmac, Base)
@@ -42,9 +43,7 @@ Hmac.prototype._update = function (data) {
 }
 
 Hmac.prototype._final = function () {
-  var h = this._hash.digest()
-  var hash = createHash(this._alg)
-  return hash.update(this._opad).update(h).digest()
+  return this._ohash.update(this._ihash.digest()).digest()
 }
 
 module.exports = function createHmac (alg, key) {

--- a/browser.js
+++ b/browser.js
@@ -47,5 +47,5 @@ Hmac.prototype._final = function () {
 }
 
 module.exports = function createHmac (alg, key) {
-  return new Hmac(alg, key)
+  return new Hmac(alg.toLowerCase(), key)
 }

--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
   },
   "dependencies": {
     "cipher-base": "^1.0.3",
-    "create-hash": "^1.1.0",
+    "create-hash": "^1.2.0",
     "inherits": "^2.0.1",
-    "ripemd160": "^2.0.0",
-    "safe-buffer": "^5.0.1",
-    "sha.js": "^2.4.8"
+    "safe-buffer": "^5.0.1"
   },
   "browser": "./browser.js"
 }


### PR DESCRIPTION
* Fixed array out of bounds bug
  - Note ((undefined ^ 0x36) == 0x36) so there's no real bug.
* Use create-hash for hashes
  - create-hash was already required but not fully used. Doing so cleans up the code a little. Also legacy is no longer used.
* Allow for fast cached HMACs
  - Cloning an `Hmac` object just after creation will allow for cached HMACs. Also if used in PBKDF2 it gets a 2x speed increase and avoids the long password DoS.